### PR TITLE
Fixes docker image name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Follow their instructions on creating a new application and git push the
 following Dockerfile to your device:
 
 ```
-FROM jannis/epaper-docker
+FROM jannis/embeddedartists-epaper
 ```
 
 The display should blink a couple of times and display the current date and


### PR DESCRIPTION
Line 26 of the README says the image is `jannis/embeddedartists-epaper` which seems to work correctly. `jannis/epaper-docker` gives an "image not found error".